### PR TITLE
Print error when command fails

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,7 +80,8 @@ var RootCmd = &cobra.Command{
 	Short: "Prometheus Alert Testing utility",
 	Run: func(cmd *cobra.Command, args []string) {
 		if code, err := run(args); err != nil {
-			fmt.Printf("exited with %d", code)
+			fmt.Println(err.Error())
+			fmt.Printf("exited %d", code)
 			os.Exit(code)
 		}
 	},


### PR DESCRIPTION
Small one, I just realised that this doesn't actually give you any info on the failure.

I had a YAML error and it was masked from me.