### PR TITLE
Support for no alert assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,11 @@ assertions:
         alertstate: firing
         job: app-server
         severity: critical
+  - at: 10m
+    expected: []
 ```
 
-In this example, we're asserting that when the alert rules are evaluated at `0m`, with the given fixtures, we should get `HTTPRequestRateLow` alert in `pending` state, and when evaluated at `5m`, the alert should be in `firing` state.
+In this example, we're asserting that when the alert rules are evaluated at `0m`, with the given fixtures, we should get `HTTPRequestRateLow` alert in `pending` state, and when evaluated at `5m`, the alert should be in `firing` state. When evaluated at `10m`, we shouldn't get any alert.
 
 A Complete Example
 ==================
@@ -182,6 +184,8 @@ assertions:
         instance: "1"
         job: app-server
         severity: critical
+    comment: |-
+      At 0m, the alerts met the threshold but has not met the duration requirement. Expect the alert to be pending
   - at: 5m
     expected:
       - alertname: HTTPRequestRateLow
@@ -196,6 +200,22 @@ assertions:
         instance: "1"
         job: app-server
         severity: critical
+    comment: |-
+      At 5m, the alerts should be firing because the duration requirement is met.
+  - at: 10m
+    expected:
+      - alertname: HTTPRequestRateLow
+        alertstate: firing
+        group: canary
+        instance: "0"
+        job: app-server
+        severity: critical
+    comment: |-
+      At 10m, the alert should be firing only for instance 0 because instance 1 is >= 100.
+  - at: 15m
+    expected: []
+    comment: |-
+      At 15m, both instances are back to normal, therefore we expect no alert.
 ```
 
 Run the test:

--- a/examples/test.yaml
+++ b/examples/test.yaml
@@ -39,3 +39,17 @@ assertions:
         severity: critical
     comment: |-
       At 5m, the alerts should be firing because the duration requirement is met.
+  - at: 10m
+    expected:
+      - alertname: HTTPRequestRateLow
+        alertstate: firing
+        group: canary
+        instance: "0"
+        job: app-server
+        severity: critical
+    comment: |-
+      At 10m, the alert should be firing only for instance 0 because instance 1 is >= 100.
+  - at: 15m
+    expected: []
+    comment: |-
+      At 15m, both instances are back to normal, therefore we expect no alert.

--- a/pkg/ruletest.go
+++ b/pkg/ruletest.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 func (prt PromRuleTest) evalRuleGroupAtInstant(suite *promql.Test, grps []*rules.Group, evalTime time.Time) ([]map[string]string, error) {
-	var retval []map[string]string
+	retval := make([]map[string]string, 0)
 
 	for _, grp := range grps {
 		for _, rule := range grp.Rules() {

--- a/pkg/ruletest_test.go
+++ b/pkg/ruletest_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/prometheus/prometheus/rules"
+	"time"
 )
 
 func TestGetTestCaseName(t *testing.T) {
@@ -29,7 +31,8 @@ func TestNewPromRuleTestFromFile(t *testing.T) {
 	assert.Equal(t, "Test HTTP Requests too low alert", promRuleTest.Name)
 	assert.Equal(t, "rules.yaml", promRuleTest.Rules.FromFile)
 	assert.Equal(t, 2, len(promRuleTest.Fixtures[0].Metrics))
-	assert.Equal(t, 2, len(promRuleTest.Assertions))
+	assert.Equal(t, 3, len(promRuleTest.Assertions))
+	assert.Equal(t, []Alert{}, promRuleTest.Assertions[2].Expected)
 	assert.Equal(t, "testdata/test.yaml", promRuleTest.filename)
 }
 
@@ -43,7 +46,8 @@ func TestNewPromRuleTestFromString(t *testing.T) {
 	assert.Equal(t, "Test HTTP Requests too low alert", promRuleTest.Name)
 	assert.Equal(t, "rules.yaml", promRuleTest.Rules.FromFile)
 	assert.Equal(t, 2, len(promRuleTest.Fixtures[0].Metrics))
-	assert.Equal(t, 2, len(promRuleTest.Assertions))
+	assert.Equal(t, 3, len(promRuleTest.Assertions))
+	assert.Equal(t, []Alert{}, promRuleTest.Assertions[2].Expected)
 	assert.Equal(t, FilenameInline, promRuleTest.filename)
 }
 
@@ -115,4 +119,12 @@ func TestAssertAlertsEqual(t *testing.T) {
 	for _, tc := range testCases {
 		assert.True(t, assertAlertsEqual(t, tc.expected, tc.actual), tc.comment)
 	}
+}
+
+func TestEvalRuleGroupAtInstantWithNoAlert(t *testing.T) {
+	prt := PromRuleTest{}
+	noAlerts, err := prt.evalRuleGroupAtInstant(nil, []*rules.Group{}, time.Now())
+
+	assert.Nil(t, err)
+	assert.Equal(t, []Alert{}, noAlerts)
 }

--- a/pkg/testdata/test.yaml
+++ b/pkg/testdata/test.yaml
@@ -35,3 +35,5 @@ assertions:
         instance: "1"
         job: app-server
         severity: critical
+  - at: 10m
+    expected: []


### PR DESCRIPTION
This PR allows to check that no alert are raised with `expected: []`.

The motivation was to be able to check that once a metric is in normal state then no alert should be raised.

This was achieved by setting the list of alerts to an empty array instead of nil.